### PR TITLE
added 'python-keystoneclient' to install_requires in setup. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
         'psycopg2',
         'PyMySQL',
         'pyodbc',
-        'python-swiftclient'
+        'python-swiftclient',
+        'python-keystoneclient'
         ],
     cmdclass={'install': CustomInstall},
     #entry_points={

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'PyMySQL',
         'pyodbc',
         'python-swiftclient',
-        'python-keystoneclient'
+        'python-keystoneclient',
         ],
     cmdclass={'install': CustomInstall},
     #entry_points={


### PR DESCRIPTION
This fixes a connection error for Auth versions 2.0 and 3.0:

> 
> Connection Error: 
> Auth versions 2.0 and 3 require python-keystoneclient, install it or use Auth
> version 1.0 which requires ST_AUTH, ST_USER, and ST_KEY environment
> variables to be set or overridden with -A, -U, or -K.